### PR TITLE
Use cdn for axios instead of the npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,5 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": "",
-  "dependencies": {
-    "axios": "^1.7.7",
-    "sweetalert2": "^11.14.5"
-  }
+  "description": ""
 }

--- a/src/index.html
+++ b/src/index.html
@@ -388,8 +388,8 @@
   </div>
   <!-- End Cart -->
   
-      <script src="../node_modules/sweetalert2/dist/sweetalert2.all.min.js"></script>
-      <script src="../node_modules/axios/dist/axios.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
       <script src="main.js"></script>
       <script src="cart.js"></script>
       <script src="home.js"></script>


### PR DESCRIPTION
Use cdn for axios instead of the npm, because of the deployement in github pages.